### PR TITLE
docs(api): Update /management api endpoints documentation

### DIFF
--- a/api/reference.rst
+++ b/api/reference.rst
@@ -2149,3 +2149,78 @@ Example Request
 
     $ curl -XDELETE http://localhost:8080/customer/90f4e211-c815-4112-9e1a-6e53de5a59c6 \
     -H 'Authorization: Key demo-key'
+
+Management
+---------
+
+Get metrics
+~~~~~~~~~~~
+
+Get metrics in prometheus format
+
+::
+
+    GET /management/metrics
+
+Example Request
++++++++++++++++
+
+.. code-block:: bash
+
+    $ curl -XGET http://localhost:8080/management/metrics \
+    -H 'Authorization: Key demo-key'
+
+
+Get good-to-go healthcheck
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The "good-to-go" healthcheck checks the database is alive and returns 200 or 503 (this can be used for a READINESS check)
+
+::
+
+    GET /management/gtg
+
+Example Request
++++++++++++++++
+
+.. code-block:: bash
+
+    $ curl -XGET http://localhost:8080/management/gtg \
+    -H 'Authorization: Key demo-key'
+
+
+Get full healthcheck
+~~~~~~~~~~~~~~~~~~~~
+
+This healthcheck checks that all reported heartbeats are not more than 4 times their timeout value and reports 200 or 503. it implicitly checks the database is up also.
+
+::
+
+    GET /management/healthcheck
+
+Example Request
++++++++++++++++
+
+.. code-block:: bash
+
+    $ curl -XGET http://localhost:8080/management/healthcheck \
+    -H 'Authorization: Key demo-key'
+
+
+Get light healthcheck
+~~~~~~~~~~~~~~~~~~~~
+
+The "underscore" healthcheck simply returns 200 OK. It does not hit the database. (this can be used for a LIVENESS check)
+
+::
+
+    GET /_
+
+Example Request
++++++++++++++++
+
+.. code-block:: bash
+
+    $ curl -XGET http://localhost:8080/_ \
+    -H 'Authorization: Key demo-key'
+


### PR DESCRIPTION
This PR update the documentation to describe the endpoints available under `/management` (following discussion in https://alerta.slack.com/archives/C01FJRJR2F2/p1636455898041700)