### PR TITLE
Fix release workflow: add tests and update gh-pages action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,18 @@ jobs:
         run:
           python3 -m pip install --upgrade pip
           pip install -r requirements.txt
+      - name: nitpick
+        id: nitpick
+        run:
+          sphinx-build -n source build
+      - name: linkcheck
+        id: linkcheck
+        run:
+          sphinx-build -M linkcheck source build || true
+      - name: spelling
+        id: spelling
+        run:
+          sphinx-build -b spelling source build/spelling
 
   release:
     name: Publish
@@ -46,7 +58,7 @@ jobs:
 
       - name: Publish to GitHub Pages
         id: publish
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: build


### PR DESCRIPTION
## Summary
- Add nitpick, linkcheck and spelling steps to the release workflow test job (were completely missing -- releases had no validation)
- Update peaceiris/actions-gh-pages from v3 to v4 (v3 uses deprecated Node.js 16)

## Test plan
- [ ] Merge, then tag `v9.1.0` to trigger the release workflow
- [ ] Verify tests run before publish
- [ ] Verify docs.alerta.io updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)